### PR TITLE
Enable i386 multiarch support for easier GUB usage

### DIFF
--- a/debian/mkosi.debian
+++ b/debian/mkosi.debian
@@ -19,6 +19,7 @@ Packages=
     make
     nano
     sudo
+    unzip
     wget
     # LilyPond dependencies
     autoconf

--- a/debian/mkosi.extra/etc/hosts
+++ b/debian/mkosi.extra/etc/hosts
@@ -1,0 +1,2 @@
+127.0.0.1   localhost.localdomain localhost
+127.0.1.1   lilypond

--- a/debian/mkosi.postinst
+++ b/debian/mkosi.postinst
@@ -73,3 +73,8 @@ do
   # use file name from HTTP header, set download location
   wget -nv -x -nH --content-disposition -P ~/.local/share/fonts "$WGETURL"
 done
+
+# Enable i386 multiarch support (for GUB)
+dpkg --add-architecture i386
+apt update
+apt install -y libc6:i386


### PR DESCRIPTION
I've tried getting GUB to work with LilyDev but it requires the ability to run 32-bit binaries (probably for cross compilation reasons?). This should do the trick. Also added a `/etc/hosts` file as otherwise `dpkg` complained.

Unfortunately the build fails due to the outdated Python version in GUB (as you described [here](https://github.com/gperciva/gub/pull/6#issuecomment-431063463)).

btw: I would've also checked Fedora but building the image fails during `./configure` of extractpdfmark...