### PR TITLE
Dockerfile: define a "lilypond" image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:18.04
+###########################################################################
+# lilypond-base: minimal image for running lilypond and its scripts
+###########################################################################
+FROM ubuntu:18.04 as lilypond-base
 
 # Allow taking Guile 1.8 (and prerequisites) from Ubuntu 16.04.
 COPY xenial.list /etc/apt/sources.list.d/xenial.list
@@ -12,10 +15,38 @@ COPY xenial.list /etc/apt/sources.list.d/xenial.list
 ## --no-install-recommends avoids installing recommended but not
 ## required packages, e.g. xterm.
 ##
-## YUCK: Testing, e.g. make test-baseline, uses git.
-##
+RUN apt-get update \
+&& DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
+    ghostscript \
+    guile-1.8 \
+    libpangoft2-1.0-0 \
+    python-all \
+&& rm -rf /var/lib/apt/lists/*
+
+###########################################################################
+# lilypond: for running LilyPond
+###########################################################################
+FROM lilypond-base as lilypond
+
+## LilyPond itself requires nothing more, but you may wish to install
+## extra packages that your personal workflow requires.  Adding them
+## here will add them to the lilypond image without adding them to the
+## lilypond-build image.  Example:
+
+# RUN apt-get update \
+# && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
+#     make \
+# && rm -rf /var/lib/apt/lists/*
+
+###########################################################################
+# lilypond-build: for LilyPond development
+###########################################################################
+FROM lilypond-base as lilypond-build
+
 COPY ./urw35fonts.sh /root
 
+## YUCK: Testing, e.g. make test-baseline, uses git.
+##
 RUN apt-get update \
 && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     autoconf \
@@ -33,7 +64,6 @@ RUN apt-get update \
     fonts-texgyre \
     g++-8 \
     gettext \
-    ghostscript \
     git \
     groff \
     gsfonts \
@@ -49,6 +79,7 @@ RUN apt-get update \
     libpango1.0-dev \
     lmodern \
     m4 \
+    make \
     mftrace \
     netpbm \
     pkg-config \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,14 @@ RUN apt-get update \
     python-all \
 && rm -rf /var/lib/apt/lists/*
 
+# The default one-line prompt gets long.  Set a two-line prompt.
+#
+# \e]2;...\a    set the window title in xterm
+# \e[1;7m       bold, reverse
+# \e[0m         normal
+#
+RUN echo 'PS1="\\[\\e]2;\\h\\a\\]\\[\\e[1;7m\\] \\h:\\w \\[\\e[0m\\]\\n\\\\$ "' >> ~/.bashrc
+
 ###########################################################################
 # lilypond: for running LilyPond
 ###########################################################################

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3.7'
 services:
   lilypond-build:
     container_name: lilypond-build
+    hostname: lilypond-build
     image: lilypond-dev
     build: .
 


### PR DESCRIPTION
1.
    Dockerfile: define a "lilypond" image
    
    The "lilypond" image is intended for running LilyPond after it has
    been built.
    
    Supporting changes to docker-compose.yaml and documentation will
    follow.  The use of the "lilypond-build" container is unchanged as
    yet.

2.
    Docker containers: set a hostname and use a two-line prompt
