### PR TITLE
Set git-bash-prompt correctly in post-install script

### DIFF
--- a/mkosi/debian/mkosi.postinst
+++ b/mkosi/debian/mkosi.postinst
@@ -18,7 +18,7 @@ export DISPLAY=:0
 export GIT_PS1_SHOWDIRTYSTATE=true
 export GIT_PS1_SHOWUNTRACKEDFILES=true
 export GIT_PS1_SHOWUPSTREAM=auto
-export PS1='[\u@\h:\W$(declare -F __git_ps1 &>/dev/null && __git_ps1 " (%s)")]\$ '
+export PS1='[\u@\h:\W\$(declare -F __git_ps1 &>/dev/null && __git_ps1 " (%s)")]\$ '
 
 # Default editor
 export EDITOR=/bin/nano

--- a/mkosi/fedora/mkosi.postinst
+++ b/mkosi/fedora/mkosi.postinst
@@ -18,7 +18,7 @@ export DISPLAY=:0
 export GIT_PS1_SHOWDIRTYSTATE=true
 export GIT_PS1_SHOWUNTRACKEDFILES=true
 export GIT_PS1_SHOWUPSTREAM=auto
-export PS1='[\u@\h:\W$(declare -F __git_ps1 &>/dev/null && __git_ps1 " (%s)")]\$ '
+export PS1='[\u@\h:\W\$(declare -F __git_ps1 &>/dev/null && __git_ps1 " (%s)")]\$ '
 
 # Default editor
 export EDITOR=/bin/nano


### PR DESCRIPTION
Fixes a missing escape backslash in the heredoc string
which was intended to add the output of __git_ps1 to
the bash prompt.