### PR TITLE
Add necessary packages for keyboard and locale setup

### DIFF
--- a/mkosi/debian/mkosi.container.d/00-mkosi.base
+++ b/mkosi/debian/mkosi.container.d/00-mkosi.base
@@ -12,7 +12,9 @@ Packages=
     ca-certificates
     git
     gitk
+    keyboard-configuration
     less
+    locales
     make
     nano
     openssh-client


### PR DESCRIPTION
The package 'locales' is needed to provide a different
locale setup than the default English one.
'keyboard-configuration' allows to setup the keyboard
layout conveniently through a console tool. 
Setting within the GUI, as mentioned in the CG,
did not work (I had to remove the English keyboard layout
completely, and even then it won't work e.g. for
the login screen)
I will update the CG to describe the usage.