### PR TITLE
Allow access to VirtualBox shared folders by default

### DIFF
--- a/mkosi/debian/mkosi.postinst
+++ b/mkosi/debian/mkosi.postinst
@@ -60,3 +60,6 @@ apt install -y libc6:i386
 echo "deb http://ftp.debian.org/debian stretch-backports main contrib" >> /etc/apt/sources.list
 apt update
 DEBIAN_FRONTEND=noninteractive apt -t stretch-backports install -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
+
+# Group membership in 'vboxsf' allow accessing VirtualBox 'shared folders'
+usermod -aG vboxsf dev


### PR DESCRIPTION
To allow access to folders which are shared between
host and guest in VirtualBox, the user must be member
in the group 'vboxsf'. Let's make this work
out-of-the-box.