### PR TITLE
Some small doc fixes and additions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
 # Contributing to LilyDev
 
 The images are built using [mkosi](https://github.com/systemd/mkosi/).
-mkosi required version is 3 or later.
+mkosi required version is 5 or later.
 
 If your distro has an older version, you should install it from source.
 Dependencies are listed on mkosi README.
+Python 3.6 is needed for mkosi 5.
+
 Then download the repository and run the installation:
 
     git clone git@github.com:systemd/mkosi.git

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ available also to Windows and Mac users (but it works on Linux too!).
 
 Containers are recommended as they are lightweight and easy to use.
 Choose the image which best suits you, download the
-[latest release](https://github.com/fedelibre/LilyDevOS/releases/latest)
+[latest release](https://github.com/fedelibre/LilyDev/releases/latest)
 and follow the instuctions in each tool README:
 
-* [mkosi](mkosi/): recommended for Linux hosts.
+* [mkosi](mkosi/): recommended for Linux hosts (container)
+or Windows hosts (VM image that runs, e.g., on VirtualBox)
 * [docker](docker/): recommended for Windows or Mac hosts.

--- a/mkosi/README.md
+++ b/mkosi/README.md
@@ -26,6 +26,9 @@ which requires VDI images.  You can generate it with this command:
 Please follow all the steps described in the LilyPond Contributor guide to
 [install and configure the VirtualBox machine](http://lilypond.org/doc/v2.19/Documentation/contributor/lilydev#installing-lilydev-in-virtualbox).
 In particular, remember that you need to enable EFI or the image won't boot.
+With the current legacy version of VirtualBox guest additions from
+stretch-backports, only the VBoxVGA graphics driver will allow to
+dynamically resize the host window.
 
 ### QEMU/libvirt
 


### PR DESCRIPTION
* Mkosi version: I could not build LilyDev with mkosi 3. The first version that worked for me
was version 5.
* Adjust infos between CG and README