### PR TITLE
Allow access to VirtualBox shared folders by default

### DIFF
--- a/mkosi/fedora/mkosi.postinst
+++ b/mkosi/fedora/mkosi.postinst
@@ -44,3 +44,7 @@ make install
 # http://lists.gnu.org/archive/html/lilypond-devel/2019-01/msg00062.html
 sudo dnf -y --releasever=27 --disablerepo=fedora-modular --disablerepo=updates-modular downgrade gcc
 echo 'exclude=gcc*' >> /etc/dnf/dnf.conf
+
+# Group membership in 'vboxsf' allow accessing VirtualBox 'shared folders'
+usermod -aG vboxsf dev
+


### PR DESCRIPTION
Allow shared folders access in VirtualBox for Fedora, too.
Note: This is untested.