### PR TITLE
Allow to build LilyDev within LilyDev

### DIFF
--- a/mkosi/debian/mkosi.container.d/00-mkosi.base
+++ b/mkosi/debian/mkosi.container.d/00-mkosi.base
@@ -79,3 +79,8 @@ Packages=
     xfonts-intl-japanese-big
     xfonts-intl-phonetic
     zip
+    # Packages required for building LilyDev
+    btrfs-tools
+    debootstrap
+    dosfstools
+    systemd-container

--- a/mkosi/debian/mkosi.extra/etc/skel/setup.sh
+++ b/mkosi/debian/mkosi.extra/etc/skel/setup.sh
@@ -18,7 +18,7 @@ fi
 
 
 ###  DOWNLOAD REPOSITORIES  ###
-if [ ! -d ~/git-cl -a ~/lilypond-git -a ~/lilypond-extra -a ~/gub -a ~/LilyDev];
+if [ ! -d ~/git-cl -a ~/lilypond-git -a ~/lilypond-extra -a ~/gub -a ~/LilyDev ];
 then
   echo "Now we'll download the repositories needed to contribute to LilyPond development. Proceed only if you have a working Internet connection."
   read -p "Press Enter to continue. "

--- a/mkosi/debian/mkosi.extra/etc/skel/setup.sh
+++ b/mkosi/debian/mkosi.extra/etc/skel/setup.sh
@@ -18,7 +18,7 @@ fi
 
 
 ###  DOWNLOAD REPOSITORIES  ###
-if [ ! -d ~/git-cl -a ~/lilypond-git -a ~/lilypond-extra ];
+if [ ! -d ~/git-cl -a ~/lilypond-git -a ~/lilypond-extra -a ~/gub -a ~/LilyDev];
 then
   echo "Now we'll download the repositories needed to contribute to LilyPond development. Proceed only if you have a working Internet connection."
   read -p "Press Enter to continue. "
@@ -32,6 +32,8 @@ then
   git clone git://git.sv.gnu.org/lilypond.git lilypond-git
   echo "Downloading gub repository..."
   git clone git://github.com/gperciva/gub.git gub
+  echo "Downloading LilyDev repository..."
+  git clone git://github.com/fedelibre/LilyDev.git
 else
   echo "Repositories already downloaded. Skipping..."
   echo

--- a/mkosi/debian/mkosi.postinst
+++ b/mkosi/debian/mkosi.postinst
@@ -63,3 +63,27 @@ DEBIAN_FRONTEND=noninteractive apt -t stretch-backports install -y virtualbox-gu
 
 # Group membership in 'vboxsf' allow accessing VirtualBox 'shared folders'
 usermod -aG vboxsf dev
+
+# We need Python 3.6 in order to run a current mkosi version
+# Python 3.6 is not available for Debian stretch, safest approach
+# is to compile it from source
+cd /home/dev
+wget https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz
+tar xf Python-3.6.9.tgz
+cd Python-3.6.9
+# compiling with --enable-optimizations creates a faster interpreter,
+# but needs plenty of time during compiling due to test runs
+./configure
+make
+# make altinstall is recommended to leave the system's old python3
+# intact, see: https://docs.python.org/3/using/unix.html#building-python
+make altinstall
+# remove build directory afterwards
+rm -r /home/dev/Python-3.6.9
+
+# Download mkosi v5 from systemd/mkosi repo and install it
+cd /home/dev
+git clone -b v5 --single-branch -depth 1 git://github.com/systemd/mkosi.git
+/usr/local/bin/python3.6 mkosi/setup.py install
+# remove sources
+rm -r mkosi

--- a/mkosi/debian/mkosi.postinst
+++ b/mkosi/debian/mkosi.postinst
@@ -70,6 +70,7 @@ usermod -aG vboxsf dev
 cd /home/dev
 wget https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz
 tar xf Python-3.6.9.tgz
+rm Python-3.6.9.tgz
 cd Python-3.6.9
 # compiling with --enable-optimizations creates a faster interpreter,
 # but needs plenty of time during compiling due to test runs
@@ -83,7 +84,8 @@ rm -r /home/dev/Python-3.6.9
 
 # Download mkosi v5 from systemd/mkosi repo and install it
 cd /home/dev
-git clone -b v5 --single-branch -depth 1 git://github.com/systemd/mkosi.git
-/usr/local/bin/python3.6 mkosi/setup.py install
+git clone -b v5 --single-branch --depth 1 git://github.com/systemd/mkosi.git
+cd mkosi
+/usr/local/bin/python3.6 setup.py install
 # remove sources
-rm -r mkosi
+rm -r /home/dev/mkosi

--- a/mkosi/fedora/mkosi.container.d/00-fedora.base
+++ b/mkosi/fedora/mkosi.container.d/00-fedora.base
@@ -52,3 +52,9 @@ Packages=
 
     # GUB dependencies
     glibc.i686
+
+    # Packages required for building LilyDev
+    btrfs-progs
+    debootstrap
+    dosfstools
+    systemd-container


### PR DESCRIPTION
I had various problems while trying to build the LilyDev VM image with mkosi. 
It took me a while to figure out which combination of debootstrap/mkosi/systemd-nspawn
works. So I thought it would be nice to have a proven-to-work setup within LilyDev for
building itself. Hopefully this can encourage contributors to contribute to LilyDev, too.

Some notes:
Building with the mkosi version of the debian stretch repo failed. The current version, however,
will work only with Python 3.6, which the repo does not provide.
So Python 3.6 is compiled during post install, it is installed beneath the Python 3.5 environment and does not overwrite it. 