### PR TITLE
Docker README whitespace fixes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,16 +12,16 @@ tools.
 1. [Install Docker](https://docs.docker.com/install/).  There is more
    than one way to do this.  On macOS you can use
    [Homebrew](https://brew.sh):
-
+   
        $ brew cask install docker
-
+   
    You might wish to explore and tweak Docker's preferences before
    using it.
-
+   
    On first run, Docker may ask for account creation or log in.
    LilyDev setup needs downloads from public repositories;
    having an account logged in could interfere. So log out:
-
+   
        $ docker logout
 
 2. The provided `docker-compose.yaml` has rules to set up a container
@@ -36,7 +36,7 @@ tools.
    ```
 
 3. Build the image for the "lilydev" service.
-
+   
        $ docker-compose build lilydev
 
 ## Routine Development
@@ -44,7 +44,7 @@ tools.
 1. Start Docker
 
 2. Start the "lilydev" container:
-
+   
        $ docker-compose up -d lilydev
 
 3. (Optional) Mount the build directory, which Docker manages
@@ -54,15 +54,15 @@ tools.
    [smb://guest:@127.0.0.1:10445/lilypond-build](smb://guest:@127.0.0.1:10445/lilypond-build).
 
 4. Log into the container:
-
+   
        $ ./enter lilydev
-
+   
    This command may be used multiple times.  It executes a new login
    shell each time.
 
 5. Build and test LilyPond.  The first step is to configure the build
    from the build directory:
-
+   
        [lilydev:~/lilypond-build]
        $ ../lilypond-src/autogen.sh
    
@@ -70,8 +70,9 @@ tools.
    Guide._
 
 6. When you are done working, type Ctrl-D and clean up:
+   
        $ docker-compose down
-
+   
     :warning: This command shuts down all running services defined in
     `docker-compose.yaml`.  If both "lilydev" and "lilypond"
     containers are running and you want to shut down just one, you
@@ -87,7 +88,7 @@ tools.
    This container leaves out most of the tools and fonts required for
    LilyPond development, and instead maps in additional directories
    from the host, specified by the following variables in `.env`.
-
+   
    ```shell
    HOST_EXTRA_FONTS_DIR=...
    HOST_SYSTEM_FONTS_DIR=...
@@ -95,19 +96,19 @@ tools.
    USER_FONTS_DIR=...
    USER_SRC_DIR=...
    ```
-
+   
    There are expected values for the three font directories on macOS
    (see [Appendix&nbsp;A](#Appendix-A)).  Any of these may be left
    unset if they are not wanted.
 
 2. Build the image for the "lilypond" service.
-
+   
        $ docker-compose build lilypond
-
 
 3. Using the "lilypond" container is like using the "lilydev"
    container.  A round of testing a new LilyPond feature on personal
    scores might begin with a global syntax update:
+   
        [lilypond:~/user-build]
        $ rm -rf *
        [lilypond:~/user-build]


### PR DESCRIPTION
I'm not sure exactly what went wrong last time I edited the README, but hopefully this will fix it.