### PR TITLE
Upgrade to Debian 10 (buster)

### DIFF
--- a/mkosi/README.md
+++ b/mkosi/README.md
@@ -26,9 +26,6 @@ which requires VDI images.  You can generate it with this command:
 Please follow all the steps described in the LilyPond Contributor guide to
 [install and configure the VirtualBox machine](http://lilypond.org/doc/v2.19/Documentation/contributor/lilydev#installing-lilydev-in-virtualbox).
 In particular, remember that you need to enable EFI or the image won't boot.
-With the current legacy version of VirtualBox guest additions from
-stretch-backports, only the VBoxVGA graphics driver will allow to
-dynamically resize the host window.
 
 ### QEMU/libvirt
 

--- a/mkosi/debian/mkosi.container.d/00-debian.base
+++ b/mkosi/debian/mkosi.container.d/00-debian.base
@@ -1,6 +1,6 @@
 [Distribution]
 Distribution=debian
-Release=stretch
+Release=buster
 
 [Packages]
 # We need a network connection when running mkosi.postinst

--- a/mkosi/debian/mkosi.extra/etc/apt/preferences
+++ b/mkosi/debian/mkosi.extra/etc/apt/preferences
@@ -1,0 +1,4 @@
+Package: *
+Pin: release n=sid
+Pin-Priority: 100
+

--- a/mkosi/debian/mkosi.postinst
+++ b/mkosi/debian/mkosi.postinst
@@ -57,9 +57,9 @@ apt install -y libc6:i386
 # might be useful also to install more recent software). It should be
 # safe, as packages from backports have low priority (100) and cannot be
 # installed accidentally.
-echo "deb http://ftp.debian.org/debian stretch-backports main contrib" >> /etc/apt/sources.list
+echo "deb http://ftp.debian.org/debian sid main contrib" >> /etc/apt/sources.list
 apt update
-DEBIAN_FRONTEND=noninteractive apt -t stretch-backports install -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
+DEBIAN_FRONTEND=noninteractive apt -t sid install -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
 
 # Group membership in 'vboxsf' allow accessing VirtualBox 'shared folders'
 usermod -aG vboxsf dev


### PR DESCRIPTION
and use virtualbox-guest-* packages from sid (version 6.x). This should
solve the problems with dynamic resize of the host window.

@michaelkaeppler Can you check if it helps with VirtualBox? And also with mkosi?
I've checked lilypond make and make doc, which works fine.
