### PR TITLE
Dockerfile: add astyle to lilypond-dev image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,7 @@ FROM lilypond-base as lilypond-dev
 USER root
 RUN apt-get update \
 && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
+    astyle \
     autoconf \
     autotools-dev \
     bison \


### PR DESCRIPTION
LilyPond master was recently restyled with astyle version 3.1, which is
the same version this Ubuntu package currently provides.