### PR TITLE
Dockerfile: python3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     ghostscript \
     guile-1.8 \
     libpangoft2-1.0-0 \
-    python-all \
+    python3 \
     sudo \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
For some reason, python-all was giving me python3 in the lilypond-dev
image, but not in the lilypond image.