### PR TITLE
Docker: UID/GID fix, GCC 12, font packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,7 +83,8 @@ RUN apt-get update \
     fonts-linuxlibertine \
     fonts-noto-cjk \
     fonts-urw-base35 \
-    g++ \
+    g++-12 \
+    gcc-12 \
     gdb \
     gettext \
     git \
@@ -122,6 +123,8 @@ RUN apt-get update \
     tidy \
     ttf-bitstream-vera \
     zip \
+&& update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 1200 \
+                       --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
 && rm -rf /var/lib/apt/lists/*
 
 # Support sharing the build directory with Samba.  If you don't need

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,6 +99,7 @@ RUN apt-get update \
     libgs-dev \
     libltdl-dev \
     libpango1.0-dev \
+    lmodern \
     m4 \
     make \
     mftrace \
@@ -111,6 +112,7 @@ RUN apt-get update \
     texi2html \
     texinfo \
     texlive-fonts-recommended \
+    texlive-font-utils \
     texlive-lang-cyrillic \
     texlive-latex-base \
     texlive-latex-recommended \

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,7 +45,7 @@ tools.
 
 2. Start the "lilydev" container:
    
-       $ docker-compose up -d lilydev
+       $ ./do start lilydev
 
 3. (Optional) Mount the build directory, which Docker manages
    internally, onto the host.  This makes it easy to review build
@@ -55,7 +55,7 @@ tools.
 
 4. Log into the container:
    
-       $ ./enter lilydev
+       $ ./do enter lilydev
    
    This command may be used multiple times.  It executes a new login
    shell each time.
@@ -71,7 +71,7 @@ tools.
 
 6. When you are done working, type Ctrl-D and clean up:
    
-       $ docker-compose down
+       $ ./do stop
    
     :warning: This command shuts down all running services defined in
     `docker-compose.yaml`.  If both "lilydev" and "lilypond"

--- a/docker/do
+++ b/docker/do
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -o errexit
+
+command=$1
+shift
+
+case "${command}" in
+    enter)
+        # Use POSIX time zone format so that we don't have to install
+        # the Olson timezone databases in the Docker image.  The trick
+        # is that we need to invert the hour offset from UTC for POSIX
+        # time.
+        TZ=$(date +%Z)$(( 12 - $(date -j -f %H%z 12+0000 +%k) ))
+        exec docker exec -e TERM -e TERM_PROGRAM -e TZ=$TZ -i -t "$@" bash -l
+        ;;
+
+    start)
+        export HOST_GID=$(id -g)
+        export HOST_UID=$(id -u)
+        exec docker-compose up -d "$@"
+        ;;
+
+    stop)
+        export HOST_GID=$(id -g)
+        export HOST_UID=$(id -u)
+        exec docker-compose down
+        ;;
+
+    *)
+        echo "${command}: unknown command" 2>&1
+        exit 1
+        ;;
+
+esac

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,7 +11,10 @@ services:
         context: .
         target: lilypond-dev
 
+    # LILYPOND_BUILD_DIR informs certain helper scripts that the build
+    # directory is not the source directory.
     environment:
+      - LILYPOND_BUILD_DIR=/home/user/lilypond-build
       - PYTHONPATH=/home/user/lilypond-src/python
 
     ports:
@@ -31,7 +34,11 @@ services:
         source: lilypond-build
         target: /home/user/lilypond-build
 
-    entrypoint: /bin/bash -c "sudo service smbd start && tail -f /dev/null"
+    # HOST_GID and HOST_UID are set in the "do" wrapper script.
+    entrypoint: /bin/bash -c "\
+           sudo service smbd start \
+        && sudo usermod -g ${HOST_GID:-X} -u ${HOST_UID:-X} user \
+        && tail -f /dev/null"
     stdin_open: false
     tty: false
 
@@ -79,7 +86,10 @@ services:
         target: /home/user/user-src
         read_only: true
 
-    entrypoint: tail -f /dev/null
+    # HOST_GID and HOST_UID are set in the "do" wrapper script.
+    entrypoint: /bin/bash -c "\
+           sudo usermod -g ${HOST_GID:-X} -u ${HOST_UID:-X} user \
+        && tail -f /dev/null"
     stdin_open: false
     tty: false
 

--- a/docker/enter
+++ b/docker/enter
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Use POSIX time zone format so that we don't have to install the
-# Olson timezone databases in the Docker image.  The trick is that we
-# need to invert the hour offset from UTC for POSIX time.
-TZ=$(date +%Z)$(( 12 - $(date -j -f %H%z 12+0000 +%k) ))
-
-set -x # echo the next command
-exec docker exec -e TERM -e TERM_PROGRAM -e TZ=$TZ -i -t $@ bash -l


### PR DESCRIPTION
* deal with having a different UID/GID on the host than in the container (see new usage in README.md)
* upgrade to GCC 12
* add fonts
