### PR TITLE
Pass "--chown" flag to COPY Dockerfile instruction

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN useradd -m -s /bin/bash user \
 && sudo -u user touch ~user/.sudo_as_admin_successful
 
 USER user
-COPY ./install/base_bashrc_addendum /home/user/base_bashrc_addendum
+COPY --chown=user:user ./install/base_bashrc_addendum /home/user/base_bashrc_addendum
 RUN cat ~/base_bashrc_addendum >> ~/.bashrc && rm ~/base_bashrc_addendum \
 && mkdir ~/lilypond-build
 


### PR DESCRIPTION
Fixes permission denied errors when building lilypond image.

I tried building using podman compose (rootless) and the single COPY instruction in the Dockerfile fails with a permission denied error (host UID not matching with Docker user "user" UID).